### PR TITLE
Neovim 0.12 compat fixes and bug cleanup

### DIFF
--- a/config/nvim/lua/config/lazy.lua
+++ b/config/nvim/lua/config/lazy.lua
@@ -25,32 +25,22 @@ vim.g.loaded_ruby_provider = 0
 vim.g.loaded_perl_provider = 0
 vim.g.mapleader = ","
 
-vim.opt.autoindent = true
-vim.opt.autoread = true
-vim.opt.backspace = { "indent", "eol", "start" }
 vim.opt.clipboard = vim.fn.has("mac") == 1 and "unnamed" or "unnamedplus"
-vim.opt.completeopt = { "menu", "menuone", "noselect" }
 vim.opt.cursorline = true
 vim.opt.cursorcolumn = true
 vim.opt.expandtab = true
 vim.opt.guicursor = "n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20" -- cursor shapes
-vim.opt.hidden = true
 vim.opt.ignorecase = true
 vim.opt.inccommand = "nosplit"
-vim.opt.incsearch = true
-vim.opt.laststatus = 2
 vim.opt.list = true
 vim.opt.listchars = { tab = "▸ ", trail = "▫" }
-vim.opt.mouse = "a"
 vim.opt.number = true
 vim.opt.pumheight = 20
 vim.opt.relativenumber = true
 vim.opt.rtp:prepend(lazypath)
-vim.opt.ruler = true
 vim.opt.scrollback = 100000
 vim.opt.scrolloff = 3
 vim.opt.shortmess:append({ c = true })
-vim.opt.showcmd = true
 vim.opt.signcolumn = "yes"
 vim.opt.smartcase = true
 vim.opt.smartindent = true
@@ -58,12 +48,10 @@ vim.opt.spelllang = "en"
 vim.opt.splitbelow = true
 vim.opt.splitright = true
 vim.opt.swapfile = false
-vim.opt.termguicolors = true
 vim.opt.undofile = true
 vim.opt.updatetime = 300
 vim.opt.visualbell = true
 vim.opt.wildignore = { "node_modules/**", "__pycache__", "*.o", "*.a" }
-vim.opt.wildmenu = true
 vim.opt.wildmode = { "longest", "list", "full" }
 vim.opt.whichwrap:append(
   { ["<"] = true, [">"] = true, h = true, l = true, ["["] = true, ["]"] = true })
@@ -148,29 +136,18 @@ vim.api.nvim_create_autocmd("FileType", {
   desc = "Quickfix window tweaks",
 })
 
--- Flash highlight when yanking text
-vim.api.nvim_create_autocmd("TextYankPost", {
-  desc = "Highlight when yanking text",
-  group = vim.api.nvim_create_augroup("kickstart-highlight-yank", { clear = true }),
-  callback = function()
-    vim.highlight.on_yank()
-  end,
-})
-
 -- Highlight cursor row/column when entering or leaving window
 vim.api.nvim_create_autocmd({ "WinEnter", "FocusGained" }, {
-  pattern = "*",
   callback = function()
-    vim.opt.cursorline = true
-    vim.opt.cursorcolumn = true
+    vim.wo.cursorline = true
+    vim.wo.cursorcolumn = true
   end,
 })
 
 vim.api.nvim_create_autocmd({ "WinLeave", "FocusLost" }, {
-  pattern = "*",
   callback = function()
-    vim.opt.cursorline = false
-    vim.opt.cursorcolumn = false
+    vim.wo.cursorline = false
+    vim.wo.cursorcolumn = false
   end,
 })
 
@@ -181,7 +158,8 @@ vim.api.nvim_create_autocmd("TermOpen", {
     vim.opt_local.number = false
     vim.opt_local.relativenumber = false
     vim.bo.buflisted = false
-    require("gitsigns").detach()
+    local ok, gs = pcall(require, "gitsigns")
+    if ok then gs.detach() end
   end,
 })
 
@@ -205,7 +183,7 @@ vim.diagnostic.config {
 vim.api.nvim_create_autocmd({ "CursorHold" }, {
   pattern = "*",
   callback = function()
-    vim.diagnostic.open_float(nil, { scope = "cursor", focusable = false })
+    vim.diagnostic.open_float({ scope = "cursor", focusable = false })
   end,
 })
 

--- a/config/nvim/lua/config/lsp/init.lua
+++ b/config/nvim/lua/config/lsp/init.lua
@@ -7,8 +7,6 @@ vim.api.nvim_create_autocmd("LspAttach", {
     local client = vim.lsp.get_client_by_id(event.data.client_id)
     local bufnr = event.buf
 
-    vim.bo[bufnr].omnifunc = "v:lua.vim.lsp.omnifunc"
-
     local opts = { noremap = true, silent = true, buffer = bufnr }
     vim.keymap.set("n", "<leader>jd", vim.lsp.buf.definition, opts)
     vim.keymap.set("n", "<leader>rs", vim.lsp.buf.rename, opts)
@@ -19,7 +17,12 @@ vim.api.nvim_create_autocmd("LspAttach", {
     vim.keymap.set("n", "<leader>F", function() vim.lsp.buf.format { async = true } end, opts)
 
     if client and client.name == "clangd" then
-      vim.keymap.set("n", "<leader>t", "<cmd>LspClangdSwitchSourceHeader<CR>", opts)
+      vim.keymap.set("n", "<leader>t", function()
+        local params = { uri = vim.uri_from_bufnr(bufnr) }
+        client:request("textDocument/switchSourceHeader", params, function(err, result)
+          if not err and result then vim.cmd.edit(vim.uri_to_fname(result)) end
+        end)
+      end, opts)
     end
   end,
 })

--- a/config/nvim/lua/config/lsp/servers/lua_ls.lua
+++ b/config/nvim/lua/config/lsp/servers/lua_ls.lua
@@ -13,7 +13,7 @@ return {
         globals = { "vim" },
       },
       workspace = {
-        library = vim.api.nvim_get_runtime_file("", true),
+        library = { vim.env.VIMRUNTIME },
         checkThirdParty = false,
       },
     },

--- a/config/nvim/lua/plugins/flash.nvim.lua
+++ b/config/nvim/lua/plugins/flash.nvim.lua
@@ -2,12 +2,10 @@ return {
   "folke/flash.nvim",
   event = "VeryLazy",
   opts = {
+    jump = { autojump = false },
     modes = {
-      search = {
-        enabled = false,
-        multi_window = false
-      },
-      jump = { autojmp = false },
+      search = { enabled = false },
+      char = { multi_window = false },
     },
   }
 }

--- a/config/nvim/lua/plugins/plantuml-syntax.lua
+++ b/config/nvim/lua/plugins/plantuml-syntax.lua
@@ -1,4 +1,3 @@
 return {
   "https://github.com/aklt/plantuml-syntax",
-  config = function(plugin) vim.opt.rtp:append(plugin.dir) end,
 }


### PR DESCRIPTION
## Summary
- Fix broken clangd switch-source-header keymap (used nonexistent `LspClangdSwitchSourceHeader` command from old lspconfig API; now uses native `client:request` directly)
- Fix flash.nvim misconfiguration: `autojmp` typo → `autojump`, move `jump` to top level, move `multi_window` to `modes.char`
- Fix cursorline/cursorcolumn autocmds to use window-local `vim.wo` instead of global `vim.opt`
- Fix deprecated `vim.diagnostic.open_float(nil, ...)` signature
- Guard `gitsigns.detach()` in TermOpen with pcall
- Remove redundant vim.opt defaults already set by Neovim (autoindent, autoread, backspace, completeopt, hidden, incsearch, laststatus, mouse, ruler, showcmd, termguicolors, wildmenu)
- Remove redundant omnifunc assignment (auto-set by LSP in 0.12)
- Remove built-in TextYankPost yank highlight autocmd (native in 0.12)
- Fix lua_ls workspace library to use `vim.env.VIMRUNTIME` instead of eager `nvim_get_runtime_file` snapshot
- Remove redundant `rtp:append` in plantuml-syntax (lazy.nvim handles this)

## Test plan
- [ ] Open nvim, confirm no startup errors
- [ ] Open a C/C++ file, verify `<leader>t` switches between source/header
- [ ] Verify cursorline/cursorcolumn only highlights the active window
- [ ] Open a terminal buffer, confirm no gitsigns error
- [ ] Verify flash.nvim `f`/`t` motions respect `multi_window = false`
- [ ] Confirm diagnostic float still appears on CursorHold

🤖 Generated with [Claude Code](https://claude.com/claude-code)